### PR TITLE
upgrade pg dependency from ^3.6.0 to ^6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "bcrypt": "^0.8.5",
     "passwordless-tokenstore": "0.0.10",
-    "pg": "^3.6.0"
+    "pg": "^6.1.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
A recent upgrade from node 5.5.0 to 6.5.0 prevented pg from connecting to the database using the correct connection string.  Upgrading pg to 6.1.0 solved the problem.
